### PR TITLE
[Fixes #1] [datapackage_tabular-data] Bug: When patching a map via api/v2/ it always receives "subtype": "tabular-collection"

### DIFF
--- a/geonode/maps/api/views.py
+++ b/geonode/maps/api/views.py
@@ -156,9 +156,13 @@ class MapViewSet(ApiPresetsInitializer, DynamicModelViewSet, AdvertisedListMixin
         map_layers = serializer.validated_data.get("maplayers", [])
         tabular_collection = all(("tabular" in layer.dataset.subtype) for layer in map_layers)
 
-        instance = serializer.save(
-            subtype="tabular-collection" if tabular_collection else None,
-        )
+        # incomming maplayer tabular check
+        map_layers = serializer.validated_data.get("maplayers", [])
+        if len(map_layers) > 0:
+            tabular_collection = all(("tabular" in layer.dataset.subtype) for layer in map_layers)
+            instance = serializer.save(
+                subtype="tabular-collection" if tabular_collection else None,
+            )
 
         # thumbnail, events and resouce routines
         self._post_change_routines(

--- a/geonode/maps/api/views.py
+++ b/geonode/maps/api/views.py
@@ -153,9 +153,6 @@ class MapViewSet(ApiPresetsInitializer, DynamicModelViewSet, AdvertisedListMixin
             "dataset_names_before_changes": [lyr.alternate for lyr in instance.datasets],
         }
 
-        map_layers = serializer.validated_data.get("maplayers", [])
-        tabular_collection = all(("tabular" in layer.dataset.subtype) for layer in map_layers)
-
         # incomming maplayer tabular check
         map_layers = serializer.validated_data.get("maplayers", [])
         if len(map_layers) > 0:


### PR DESCRIPTION
## Checklist

closes GeoNodeUserGroup-DE/geonode-dev-datapackage#42 
